### PR TITLE
.travis.yml file, relocate github releases + remove `on: repo:`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,13 @@ before_deploy:
 - tar -czvf felix-linux.tgz build/release/host build/release/share
 
 deploy:
-  skip_cleanup: true
   provider: releases
   api_key:
     secure: n5+jnBuG3JZAoMMuBpkTtewiazORSRkQWje/yiwaT3NaU+IdfLFBnkazp5+QD7Ox7Z5auXOM1ngtJWykf5wPDjAtpKc4C82o67nvUgBJzS3+PvFNUWXCW+8rzPGJ6Xn9wiqP80XucQvmsAgfY8UCP4Hj8DswjDgVOR5utucyRj4=
   file: felix-linux.tgz
+  skip_cleanup: true
   on:
     tags: true
-    repo: felix-lang/felix
 
 notifications:
   email: felix-builds@googlegroups.com


### PR DESCRIPTION
This should fix GitHub releases deployment here's the tagged commit and its corresponding build failing due to permissions: `(Octokit::Unauthorized)`

- tag: https://github.com/MariadeAnton/felix/releases/tag/trial-release , build: https://travis-ci.org/MariadeAnton/felix/builds/87649711

Hope it helps!