### PR TITLE
Fixed unable to locate dyld lib during build

### DIFF
--- a/buildscript/osxsetup.sh
+++ b/buildscript/osxsetup.sh
@@ -1,3 +1,2 @@
 export PATH=build/release/host/bin:$PATH
-export DYLD_LIBRARY_PATH=build/release/host/lib/rtl:$DYLD_LIBRARY_PATH
-
+export DYLD_LIBRARY_PATH=build/release/host/lib/rtl${DYLD_LIBRARY_PATH:+:}${DYLD_LIBRARY_PATH:-}


### PR DESCRIPTION
Error due to path having colon at end if var wasn't defined