### PR TITLE
Remove stray character in docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -434,7 +434,7 @@ Travis, Linux build: <a href= https://travis-ci.org/felix-lang/felix><img src=ht
 <tr><th>Title                                <th> URL
 <tr><td>Documentation Master                 <td> <a href=http://felix-documentation-master.readthedocs.io/en/latest>http://felix-documentation-master.readthedocs.io/en/latest</a>
 <tr><td>Felix Tutorial                       <td> <a href=http://felix-tutorial.readthedocs.io/en/latest>http://felix-tutorial.readthedocs.io/en/latest</a>
-<tr><td>Installation and Tools Guide         <td> <a href=http://felix-tools.readthedocs.io/en/latest>=http://felix-tools.readthedocs.io/en/latest</a>
+<tr><td>Installation and Tools Guide         <td> <a href=http://felix-tools.readthedocs.io/en/latest>http://felix-tools.readthedocs.io/en/latest</a>
 <tr><td>Felix Language Reference Manual      <td> <a href=http://felix.readthedocs.io/en/latest>http://felix.readthedocs.io/en/latest</a>
 <tr><td>Felix Library Packages               <td> <a href=http://felix-library-packages.readthedocs.io/en/latest>http://felix-library-packages.readthedocs.io/en/latest</a>
 <tr><td>Articles on Modern Computing         <td> <a href=http://modern-computing.readthedocs.io/en/latest>http://modern-computing.readthedocs.io/en/latest</a>


### PR DESCRIPTION
Just removed an `=`.