### PR TITLE
Fixed the build process compatibility with Python 3.8.

### DIFF
--- a/fbuild/lib/fbuild/config/__init__.py
+++ b/fbuild/lib/fbuild/config/__init__.py
@@ -30,7 +30,11 @@ class TestMeta(fbuild.db.PersistentMeta):
             return super().__new__(cls, name, bases, attrs)
 
         module = attrs.pop('__module__')
-        new_class = super().__new__(cls, name, bases, {'__module__': module})
+        new_attrs = {'__module__': module}
+        classcell = attrs.pop('__classcell__', None)
+        if classcell is not None:
+            new_attrs['__classcell__'] = classcell
+        new_class = super().__new__(cls, name, bases, new_attrs)
         new_class.__field_names__ = []
 
         for parent in parents:


### PR DESCRIPTION
Addressed the RuntimeError during the `make` command (please see https://docs.python.org/3.9/whatsnew/3.8.html#changes-in-the-python-api):

> A RuntimeError is now raised when the custom metaclass doesn’t provide the `__classcell__` entry in the namespace passed to `type.__new__`. A DeprecationWarning was emitted in Python 3.6–3.7.