### PR TITLE
added (provide 'felix-mode)

### DIFF
--- a/src/misc/emacs/felix-mode.el
+++ b/src/misc/emacs/felix-mode.el
@@ -1,4 +1,7 @@
 ;; Felix-mode
+;;
+;;  add (require 'felix-mode) to your .emacs file
+;;
 
 (require 'generic-x)
 
@@ -406,3 +409,4 @@
 
 (add-hook 'felix-mode-hook 'flymake-mode)
 
+(provide 'felix-mode)


### PR DESCRIPTION
I added (provide 'felix-mode) to the end of the felix-mode.el emacs lisp file
to get it working by using (require 'felix-mode) in my emacs26.