### PR TITLE
Fix clang build on Linux with blocks flag

### DIFF
--- a/fbuildroot.py
+++ b/fbuildroot.py
@@ -296,8 +296,9 @@ def make_cxx_builder(ctx, *args, includes=[], libpaths=[], flags=[], **kwargs):
             'optimize_flags': ['-fomit-frame-pointer']}),
         ({'posix'}, {
             'warnings': ['fatal-errors', 'no-invalid-offsetof','no-parentheses'],
-            'flags': ['-std=c++14', '-D_POSIX', '-w',
-               '-fno-common', '-fvisibility=hidden', '-fno-strict-aliasing'] + flags,
+            'flags': ['-std=c++14', '-fblocks', '-D_POSIX', '-w',
+               '-fno-common', '-fvisibility=hidden', '-fno-strict-aliasing',
+               '-fblocks'] + flags,
             'optimize_flags': ['-fomit-frame-pointer']}),
         ({'windows'}, {
             'link_flags' : ['/DEBUG'],

--- a/src/packages/toolchain.fdoc
+++ b/src/packages/toolchain.fdoc
@@ -1322,7 +1322,7 @@ object toolchain_clang_linux (config:toolchain_config_t) implements toolchain_t 
   var ccflags_for_dynamic_link = list[string] ("-shared");
 
   var base_cxx_compile_flags =  
-     "-std=c++14"! "-g"! "-c" ! "-O1" ! "-fno-common"! "-fno-strict-aliasing" ! (cxx_compile_warning_flags+config.ccflags)
+     "-std=c++14"! "-g"! "-c" ! "-O1" ! "-fno-common"! "-fno-strict-aliasing" ! "-fblocks" ! (cxx_compile_warning_flags+config.ccflags)
   ;
 
   var base_c_compile_flags =  


### PR DESCRIPTION
e29cf791 added template names for clang blocks.

Linux distros which do not support clang blocks by default, e.g. Arch
Linux, need the -fblocks flag.